### PR TITLE
set defines and localisation so there are 9 unit levels

### DIFF
--- a/common/defines/mod_defines.lua
+++ b/common/defines/mod_defines.lua
@@ -41,7 +41,10 @@ NDefines.NMilitary.MAX_AIR_EXPERIENCE = 999		--vanilla=500
 NDefines.NMilitary.TRAINING_ATTRITION = 0.01	--vanilla=0.06
 NDefines.NMilitary.UNIT_LEADER_USE_NONLINEAR_XP_GAIN = false	--vanilla=true
 NDefines.NMilitary.GARRISON_ORDER_ARMY_CAP_FACTOR = 1	--vanilla=3
-NDefines.NMilitary.ARMY_TRAINING_FUEL_MULT = 0	--vanilla=1.0
+NDefines.NMilitary.ARMY_TRAINING_FUEL_MULT = 0	--vanilla=1.
+NDefines.NMilitary.UNIT_EXP_LEVELS = { 0.02, 0.15, 0.225, 0.35, 0.5, 0.7, 0.925, 1.15 } --vanilla={0.1, 0.3, 0.75, 0.9}
+NDefines.NMilitary.EXPERIENCE_COMBAT_FACTOR = 0.107 --vanilla=0.25
+
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 NDefines.NAir.AIR_WING_MAX_SIZE = 1600	--vanilla=1000
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/localisation/english/zzz_mod_core_l_english.yml
+++ b/localisation/english/zzz_mod_core_l_english.yml
@@ -1,0 +1,10 @@
+﻿l_english:
+ UNIT_LEVEL_0:0 "Green"
+ UNIT_LEVEL_1:0 "Trained"
+ UNIT_LEVEL_2:0 "Regulars"
+ UNIT_LEVEL_3:0 "Experienced"
+ UNIT_LEVEL_4:0 "Hardened"
+ UNIT_LEVEL_5:0 "Seasoned"
+ UNIT_LEVEL_6:0 "Veterans"
+ UNIT_LEVEL_7:0 "Battle-Scarred"
+ UNIT_LEVEL_8:0 "Crack"


### PR DESCRIPTION
set defines and localisation so there are 9 unit levels
- Set levels to scale exponentially and set max level at a higher amount of XP
- Modify experience per level to 10.7% so that the total is still approximately 75%