### PR TITLE
Germany total mob

### DIFF
--- a/common/ideas/_economic.txt
+++ b/common/ideas/_economic.txt
@@ -386,7 +386,12 @@ ideas = {
 					limit = {
 						original_tag = GER
 					}
-					has_war_with = SOV
+					OR = {
+						FRA = {
+							 has_capitulated = yes
+						}
+						date > 1941.1.1
+					}
 				}
 				
 				if = {


### PR DESCRIPTION
Set Germany to require the capitulation of France or Jan 1 1941 for getting total mob
remove requirement to be at war with soviets