### PR TITLE
Doctrine switching reduction

### DIFF
--- a/common/on_actions/bsmod_generic_on_startups.txt
+++ b/common/on_actions/bsmod_generic_on_startups.txt
@@ -4,99 +4,57 @@ on_actions = {
 			every_country = {
 				if = {
 					limit = {
-						land_doctrine_level > 0
+						has_tech = mobile_warfare
 					}
-					if = {
-						limit = {
-							has_tech = mobile_warfare
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_grand_battle_plan
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_superior_firepower
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_mass_assault
-						}
+					add_doctrine_cost_reduction = {
+						name = STARTING_COST_REDUCTION
+						cost_reduction = 0.5
+						uses = 1
+						category = first_land_doctrine
 					}
-					else_if = {
-						limit = {
-							has_tech = superior_firepower
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_grand_battle_plan
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_mobile_warfare
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_mass_assault
-						}
+				}
+				else_if = {
+					limit = {
+						has_tech = superior_firepower
 					}
-					else_if = {
-						limit = {
-							has_tech = grand_battle_plan
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_superior_firepower
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_mobile_warfare
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_mass_assault
-						}
+					add_doctrine_cost_reduction = {
+						name = STARTING_COST_REDUCTION
+						cost_reduction = 0.5
+						uses = 1
+						category = first_land_doctrine
 					}
-					else_if = {
-						limit = {
-							has_tech = mass_assault
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_superior_firepower
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_mobile_warfare
-						}
-						add_doctrine_cost_reduction = {
-							name = STARTING_COST_REDUCTION
-							cost_reduction = 0.5
-							uses = 1
-							category = cat_grand_battle_plan
-						}
+				}
+				else_if = {
+					limit = {
+						has_tech = grand_battle_plan
+					}
+					add_doctrine_cost_reduction = {
+						name = STARTING_COST_REDUCTION
+						cost_reduction = 0.5
+						uses = 1
+						category = first_land_doctrine
+					}
+				}
+				else_if = {
+					limit = {
+						has_tech = mass_assault
+					}
+					add_doctrine_cost_reduction = {
+						name = STARTING_COST_REDUCTION
+						cost_reduction = 0.5
+						uses = 1
+						category = first_land_doctrine
+					}
+				}
+				else_if = {
+					limit = {
+						land_doctrine_level < 1
+					}
+					add_doctrine_cost_reduction = {
+						name = STARTING_COST_REDUCTION
+						cost_reduction = 0.5
+						uses = 1
+						category = first_land_doctrine
 					}
 				}
 			}

--- a/common/on_actions/bsmod_generic_on_startups.txt
+++ b/common/on_actions/bsmod_generic_on_startups.txt
@@ -1,0 +1,105 @@
+on_actions = {
+	on_startup = {
+		effect = {
+			every_country = {
+				if = {
+					limit = {
+						land_doctrine_level > 0
+					}
+					if = {
+						limit = {
+							has_tech = mobile_warfare
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_grand_battle_plan
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_superior_firepower
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_mass_assault
+						}
+					}
+					else_if = {
+						limit = {
+							has_tech = superior_firepower
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_grand_battle_plan
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_mobile_warfare
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_mass_assault
+						}
+					}
+					else_if = {
+						limit = {
+							has_tech = grand_battle_plan
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_superior_firepower
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_mobile_warfare
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_mass_assault
+						}
+					}
+					else_if = {
+						limit = {
+							has_tech = mass_assault
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_superior_firepower
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_mobile_warfare
+						}
+						add_doctrine_cost_reduction = {
+							name = STARTING_COST_REDUCTION
+							cost_reduction = 0.5
+							uses = 1
+							category = cat_grand_battle_plan
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/technologies/land_doctrine.txt
+++ b/common/technologies/land_doctrine.txt
@@ -34,6 +34,7 @@ technologies = {
 		categories = {
 			land_doctrine
 			cat_mobile_warfare
+			first_land_doctrine
 		}
 		
 		ai_will_do = {
@@ -937,6 +938,7 @@ technologies = {
 		categories = {
 			land_doctrine
 			cat_superior_firepower
+			first_land_doctrine
 		}
 
 		
@@ -1823,6 +1825,7 @@ technologies = {
 		categories = {
 			land_doctrine
 			cat_grand_battle_plan
+			first_land_doctrine
 		}
 
 		
@@ -2628,6 +2631,7 @@ technologies = {
 		categories = {
 			land_doctrine
 			cat_mass_assault
+			first_land_doctrine
 		}
 
 		

--- a/common/technology_tags/00_technology.txt
+++ b/common/technology_tags/00_technology.txt
@@ -93,6 +93,7 @@ technology_categories = {
 	cat_production
 	cat_synth_rubber
 	cat_synth_oil
+	first_land_doctrine
 }
 
 technology_folders = {

--- a/localisation/english/mod_misc_l_english.yml
+++ b/localisation/english/mod_misc_l_english.yml
@@ -1,2 +1,2 @@
 ﻿l_english: 
- STARTING_COST_REDUCTION:0 "Starting cost reduction for doctrine switching"
+ STARTING_COST_REDUCTION:0 "One cost reduction for doctrine switching"

--- a/localisation/english/mod_misc_l_english.yml
+++ b/localisation/english/mod_misc_l_english.yml
@@ -1,0 +1,2 @@
+﻿l_english: 
+ STARTING_COST_REDUCTION:0 "Starting cost reduction for doctrine switching"


### PR DESCRIPTION
Added tech tag to each of the initial land doctrine techs:
- mobile warfare
- superior firepower
- mass assault
- grand battleplan

Added on_startup to add a single doctrine cost reduction to enable switching doctrines more easily. Only works once.
