### PR TITLE
Nerf tank sup cmpys

### DIFF
--- a/common/units/recon.txt
+++ b/common/units/recon.txt
@@ -288,10 +288,10 @@ sub_units = {
 		can_be_parachuted = yes
 
 		# Support nerfs to combat abilities
-		defense = -0.5
-		breakthrough = -0.2
-		soft_attack = -0.5
-		hard_attack = -0.5
+		defense = -0.6
+		breakthrough = -0.6
+		soft_attack = -0.6
+		hard_attack = -0.6
 		essential = {
 			light_tank_chassis
 		}


### PR DESCRIPTION
 reduce light recon tank stats so they are more in-line with their total equipment amount compared to a regular light tank battalion. Stats are 40% of the equipment values

